### PR TITLE
v0.4.2 improve engine loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 
 #### v0.4.2
 
+- Set engine selection list with engines that are installed
+- Wait until engine is loaded before trying to load next engine
+- Do not offer mx.samples engine when there are no audio/mx.samples
 - For midi_out.pitch_bend_value() reuse, pass pitchbend semitones as 2nd argument
 
 #### v0.4.1

--- a/lib/functions.lua
+++ b/lib/functions.lua
@@ -13,6 +13,23 @@ function pf.dprint(t, s)
   end
 end
 
+--- Check if a file or directory exists in this path
+function pf.exists(file)
+   local ok, err, code = os.rename(file, file)
+   if not ok then
+      if code == 13 then
+         -- Permission denied, but it exists
+         return true
+      end
+   end
+   return ok, err
+end
+
+--- Check if a directory exists in this path
+function pf.isdir(path)
+   return pf.exists(path.."/")
+end
+
 function pf.gcd(a,b)
   while b~=0 do
     a,b=b,a%b
@@ -414,7 +431,9 @@ end
 function pf.text(l,x,y,t)
   s.level(l)
   s.move(x,y)
-  s.text(t)
+  if t ~= nil then
+    s.text(t)
+  end
 end
 
 local note = {

--- a/lib/patch.lua
+++ b/lib/patch.lua
@@ -22,6 +22,23 @@ for f in io.popen("ls -a /home/we/dust/audio"):lines() do
   end
 end
 
+function patch.installed_engines()
+  local engines = {"PolyPerc"}
+
+  for f in io.popen("ls -a /home/we/dust/code"):lines() do
+    if f == "molly_the_poly" then
+      table.insert(engines, "MollyThePoly")
+    elseif f == "mx.samples" then
+      if pf.isdir("/home/we/dust/audio/mx.samples") then
+        table.insert(engines, "MxSamples")
+      end
+    elseif f == "synthy" then
+      table.insert(engines, "Synthy")
+    end
+  end
+  return engines
+end
+
 function patch.mx_samples()
   return mx_samples
 end
@@ -83,11 +100,22 @@ function patch.note_kill_all()
   end
 end
 
+local patch_loading = false
 function patch.load_engine(name)
-  if name ~= engine.name then
+  if patch_loading then
+    return nil
+  elseif name ~= engine.name then
+    patch_loading = true
     print("load_engine: ", name, " previous_engine: ", engine.name)
     patch.note_off_all()
-    engine.load(name, patch.handle_load)
+    if pcall(engine.load, name, patch.handle_load) then
+      patch_loading = false
+      print("pcall ok")
+    else
+      patch_loading = false
+      print("pcall fail")
+      params:set("pitfalls_engine", 1)
+    end
   end
 end
 

--- a/pitfalls.lua
+++ b/pitfalls.lua
@@ -43,7 +43,7 @@
 --           docs/modename.html
 -- .................................................................
 --
--- pitfalls 0.4.1 ostinato odington release
+-- pitfalls 0.4.2 ostinato odington release
 -- copyright 02022 robmckinnon
 -- GNU GPL v3.0
 -- .................................................................


### PR DESCRIPTION
v0.4.2

- Set engine selection list with engines that are installed
- Wait until engine is loaded before trying to load next engine
- Do not offer mx.samples engine when there are no audio/mx.samples
- For midi_out.pitch_bend_value() reuse, pass pitchbend semitones as 2nd argument

